### PR TITLE
Add assigned start and end to DRS booking creation

### DIFF
--- a/HousingRepairsSchedulingApi.Tests/ServicesTests/Drs/DrsServiceTests.cs
+++ b/HousingRepairsSchedulingApi.Tests/ServicesTests/Drs/DrsServiceTests.cs
@@ -310,6 +310,7 @@ namespace HousingRepairsSchedulingApi.Tests.ServicesTests.Drs
             // Assert
             soapMock.Verify(schedulingBookingExpression);
             Assert.True(request.scheduleBooking1.theBooking.assignedStartSpecified);
+            Assert.True(request.scheduleBooking1.theBooking.assignedEndSpecified);
 
         }
 

--- a/HousingRepairsSchedulingApi.Tests/ServicesTests/Drs/DrsServiceTests.cs
+++ b/HousingRepairsSchedulingApi.Tests/ServicesTests/Drs/DrsServiceTests.cs
@@ -295,8 +295,12 @@ namespace HousingRepairsSchedulingApi.Tests.ServicesTests.Drs
 #pragma warning restore CA1707
         {
             // Arrange
+            scheduleBooking request = null;
+
             Expression<Action<SOAP>> schedulingBookingExpression = x => x.scheduleBookingAsync(It.IsAny<scheduleBooking>());
-            soapMock.Setup(schedulingBookingExpression);
+            soapMock.Setup(schedulingBookingExpression)
+                .Callback<scheduleBooking>(r => request = r);
+
             var startDate = new DateTime(2022, 1, 21);
             var endDate = startDate.AddDays(1);
 
@@ -305,6 +309,8 @@ namespace HousingRepairsSchedulingApi.Tests.ServicesTests.Drs
 
             // Assert
             soapMock.Verify(schedulingBookingExpression);
+            Assert.True(request.scheduleBooking1.theBooking.assignedStartSpecified);
+
         }
 
         public static IEnumerable<object[]> InvalidArgumentTestData()

--- a/HousingRepairsSchedulingApi/Services/Drs/DrsService.cs
+++ b/HousingRepairsSchedulingApi/Services/Drs/DrsService.cs
@@ -131,6 +131,10 @@ namespace HousingRepairsSchedulingApi.Services.Drs
                     primaryOrderNumber = bookingReference,
                     planningWindowStart = startDateTime,
                     planningWindowEnd = endDateTime,
+                    assignedStart = startDateTime,
+                    assignedEnd = endDateTime,
+                    assignedStartSpecified = true,
+                    assignedEndSpecified = true
                 }
             };
 


### PR DESCRIPTION
The call to DRS is missing the assigned start and end as per Cyndi's comments in Slack: 

https://hackit-lbh.slack.com/archives/C017N5GA8P8/p1661173306257469?thread_ts=1661167453.360089&cid=C017N5GA8P8

Therefore, add these to the call to ensure the appointment is assigned