### PR TITLE
MR-510 - Added one line for additional logging output

### DIFF
--- a/HousingRepairsSchedulingApi/Gateways/DrsAppointmentGateway.cs
+++ b/HousingRepairsSchedulingApi/Gateways/DrsAppointmentGateway.cs
@@ -104,6 +104,8 @@ namespace HousingRepairsSchedulingApi.Gateways
             Guard.Against.NullOrWhiteSpace(locationId, nameof(locationId));
             Guard.Against.OutOfRange(endDateTime, nameof(endDateTime), startDateTime, DateTime.MaxValue);
 
+            _logger.LogInformation($"Appointment times for booking reference {bookingReference} after Guard clauses - start time is {startDateTime} and end time is {endDateTime}.");
+
             var bookingId = await _drsService.CreateOrder(bookingReference, sorCode, locationId);
 
             var convertedStartTime = DrsHelpers.ConvertToDrsTimeZone(startDateTime);


### PR DESCRIPTION
Added one line for additional logging output to see if Datetime values are affected after the Guard clauses, after being unable to replicate the error in a test.

Error: `"Serialization and deserialization of \u0027System.IntPtr\u0027 instances are not supported. Path: $.TargetSite.MethodHandle.Value."`

Test (showing a correct timeslot):
![image](https://user-images.githubusercontent.com/70756861/188617564-cea69aef-66f5-4967-874b-cc76f34487de.png)

The logging above should work as an extra confirmation that the dates, are correct before the method ConvertToDrsTimeZone is called on each date.
