### PR TITLE
MR-510 - Commented out ConvertToDrsTimeZone 

### DIFF
--- a/HousingRepairsSchedulingApi/Gateways/DrsAppointmentGateway.cs
+++ b/HousingRepairsSchedulingApi/Gateways/DrsAppointmentGateway.cs
@@ -107,12 +107,16 @@ namespace HousingRepairsSchedulingApi.Gateways
 
             _logger.LogInformation($"Order created successfully for {bookingReference}");
 
-            var convertedStartTime = DrsHelpers.ConvertToDrsTimeZone(startDateTime);
-            var convertedEndTime = DrsHelpers.ConvertToDrsTimeZone(endDateTime);
+            //var convertedStartTime = DrsHelpers.ConvertToDrsTimeZone(startDateTime);
+            //var convertedEndTime = DrsHelpers.ConvertToDrsTimeZone(endDateTime);
 
-            _logger.LogInformation($"Converted times for booking reference {bookingReference} - start time is {convertedStartTime} and end time is {convertedEndTime} prior to sending to DRS");
+            //_logger.LogInformation($"Converted times for booking reference {bookingReference} - start time is {convertedStartTime} and end time is {convertedEndTime} prior to sending to DRS");
 
-            await _drsService.ScheduleBooking(bookingReference, bookingId, convertedStartTime, convertedEndTime);
+            //await _drsService.ScheduleBooking(bookingReference, bookingId, convertedStartTime, convertedEndTime);
+
+            _logger.LogInformation($"ConvertToDrsTimeZone has been temporarily removed for troubleshooting purposes. About to call _drsService.ScheduleBooking with non-converted times - Booking reference {bookingReference}");
+
+            await _drsService.ScheduleBooking(bookingReference, bookingId, startDateTime, endDateTime);
 
             return bookingReference;
         }

--- a/HousingRepairsSchedulingApi/Gateways/DrsAppointmentGateway.cs
+++ b/HousingRepairsSchedulingApi/Gateways/DrsAppointmentGateway.cs
@@ -101,14 +101,16 @@ namespace HousingRepairsSchedulingApi.Gateways
             Guard.Against.NullOrWhiteSpace(locationId, nameof(locationId));
             Guard.Against.OutOfRange(endDateTime, nameof(endDateTime), startDateTime, DateTime.MaxValue);
 
-            _logger.LogInformation($"Appointment times for booking reference {bookingReference} - start time is {startDateTime} and end time is {endDateTime}.");
+            _logger.LogInformation($"Appointment times for booking reference {bookingReference} - start time is {startDateTime} and end time is {endDateTime}");
 
             var bookingId = await _drsService.CreateOrder(bookingReference, sorCode, locationId);
+
+            _logger.LogInformation($"Order created successfully for {bookingReference}");
 
             var convertedStartTime = DrsHelpers.ConvertToDrsTimeZone(startDateTime);
             var convertedEndTime = DrsHelpers.ConvertToDrsTimeZone(endDateTime);
 
-            _logger.LogInformation($"Converted times for booking reference {bookingReference} - start time is {convertedStartTime} and end time is {convertedEndTime} prior to sending to DRS.");
+            _logger.LogInformation($"Converted times for booking reference {bookingReference} - start time is {convertedStartTime} and end time is {convertedEndTime} prior to sending to DRS");
 
             await _drsService.ScheduleBooking(bookingReference, bookingId, convertedStartTime, convertedEndTime);
 

--- a/HousingRepairsSchedulingApi/Services/Drs/DrsService.cs
+++ b/HousingRepairsSchedulingApi/Services/Drs/DrsService.cs
@@ -98,6 +98,8 @@ namespace HousingRepairsSchedulingApi.Services.Drs
 
             await EnsureSessionOpened();
 
+            LambdaLogger.Log($"About to call CreateOrder with following parameters booking reference: {bookingReference}, sorCode {sorCode}, locationId {locationId};");
+
             var createOrder = new xmbCreateOrder
             {
                 sessionId = _sessionId,
@@ -123,10 +125,14 @@ namespace HousingRepairsSchedulingApi.Services.Drs
                 }
             };
 
+            LambdaLogger.Log($"Built create order object {bookingReference}, sorCode {sorCode}, locationId {locationId};");
+
             try
             {
                 var createOrderResponse = await _drsSoapClient.createOrderAsync(new createOrder(createOrder));
                 var result = createOrderResponse.@return.theOrder.theBookings[0].bookingId;
+
+                LambdaLogger.Log($"Successfully called createOrderAsync with {bookingReference}, response booking ID {result};");
 
                 return result;
             }


### PR DESCRIPTION
ConvertToDrsTimeZone method has been temporarily commented out for troubleshooting purposes to narrow down the cause of the error seen in Cloudwatch.

`2022-09-07T11:48:26.332Z	f8928840-972d-462e-90bb-5ae18037bce4	An error was thrown when calling bookAppointmentUseCase: "Serialization and deserialization of \u0027System.IntPtr\u0027 instances are not supported. Path: $.TargetSite.MethodHandle.Value."`