### PR TITLE
MR-510 - Added log to show response object after API call (createOrder) to DRS

### DIFF
--- a/HousingRepairsSchedulingApi/Gateways/DrsAppointmentGateway.cs
+++ b/HousingRepairsSchedulingApi/Gateways/DrsAppointmentGateway.cs
@@ -107,12 +107,16 @@ namespace HousingRepairsSchedulingApi.Gateways
 
             _logger.LogInformation($"Order created successfully for {bookingReference}");
 
-            var convertedStartTime = DrsHelpers.ConvertToDrsTimeZone(startDateTime);
-            var convertedEndTime = DrsHelpers.ConvertToDrsTimeZone(endDateTime);
+            //var convertedStartTime = DrsHelpers.ConvertToDrsTimeZone(startDateTime);
+            //var convertedEndTime = DrsHelpers.ConvertToDrsTimeZone(endDateTime);
 
-            _logger.LogInformation($"Converted times for booking reference {bookingReference} - start time is {convertedStartTime} and end time is {convertedEndTime} prior to sending to DRS");
+            //_logger.LogInformation($"Converted times for booking reference {bookingReference} - start time is {convertedStartTime} and end time is {convertedEndTime} prior to sending to DRS");
 
-            await _drsService.ScheduleBooking(bookingReference, bookingId, convertedStartTime, convertedEndTime);
+            //await _drsService.ScheduleBooking(bookingReference, bookingId, convertedStartTime, convertedEndTime);
+
+            _logger.LogInformation($"ConvertToDrsTimeZone has been temporarily removed for troubleshooting purposes. About to call _drsService.ScheduleBooking with non-converted times - Booking reference {bookingReference}");
+
+            await _drsService.ScheduleBooking(bookingReference, bookingId, startDateTime, endDateTime);
 
             return bookingReference;
         }

--- a/HousingRepairsSchedulingApi/Gateways/DrsAppointmentGateway.cs
+++ b/HousingRepairsSchedulingApi/Gateways/DrsAppointmentGateway.cs
@@ -101,14 +101,16 @@ namespace HousingRepairsSchedulingApi.Gateways
             Guard.Against.NullOrWhiteSpace(locationId, nameof(locationId));
             Guard.Against.OutOfRange(endDateTime, nameof(endDateTime), startDateTime, DateTime.MaxValue);
 
-            _logger.LogInformation($"Appointment times for booking reference {bookingReference} - start time is {startDateTime} and end time is {endDateTime}.");
+            _logger.LogInformation($"Appointment times for booking reference {bookingReference} - start time is {startDateTime} and end time is {endDateTime}");
 
             var bookingId = await _drsService.CreateOrder(bookingReference, sorCode, locationId);
+
+            _logger.LogInformation($"Order created successfully for {bookingReference}");
 
             var convertedStartTime = DrsHelpers.ConvertToDrsTimeZone(startDateTime);
             var convertedEndTime = DrsHelpers.ConvertToDrsTimeZone(endDateTime);
 
-            _logger.LogInformation($"Converted times for booking reference {bookingReference} - start time is {convertedStartTime} and end time is {convertedEndTime} prior to sending to DRS.");
+            _logger.LogInformation($"Converted times for booking reference {bookingReference} - start time is {convertedStartTime} and end time is {convertedEndTime} prior to sending to DRS");
 
             await _drsService.ScheduleBooking(bookingReference, bookingId, convertedStartTime, convertedEndTime);
 

--- a/HousingRepairsSchedulingApi/Services/Drs/DrsService.cs
+++ b/HousingRepairsSchedulingApi/Services/Drs/DrsService.cs
@@ -131,7 +131,7 @@ namespace HousingRepairsSchedulingApi.Services.Drs
             {
                 var createOrderResponse = await _drsSoapClient.createOrderAsync(new createOrder(createOrder));
 
-                LambdaLogger.Log($"Successfully called createOrderAsync with {bookingReference}.");
+                LambdaLogger.Log($"Successfully called createOrderAsync with {bookingReference}. createOrderResponse: {JsonSerializer.Serialize(createOrderResponse)}");
 
                 var result = createOrderResponse.@return.theOrder.theBookings[0].bookingId;
 

--- a/HousingRepairsSchedulingApi/Services/Drs/DrsService.cs
+++ b/HousingRepairsSchedulingApi/Services/Drs/DrsService.cs
@@ -98,6 +98,8 @@ namespace HousingRepairsSchedulingApi.Services.Drs
 
             await EnsureSessionOpened();
 
+            LambdaLogger.Log($"About to call CreateOrder with following parameters booking reference: {bookingReference}, sorCode {sorCode}, locationId {locationId};");
+
             var createOrder = new xmbCreateOrder
             {
                 sessionId = _sessionId,
@@ -123,10 +125,14 @@ namespace HousingRepairsSchedulingApi.Services.Drs
                 }
             };
 
+            LambdaLogger.Log($"Built create order object {bookingReference}, sorCode {sorCode}, locationId {locationId};");
+
             try
             {
                 var createOrderResponse = await _drsSoapClient.createOrderAsync(new createOrder(createOrder));
                 var result = createOrderResponse.@return.theOrder.theBookings[0].bookingId;
+
+                LambdaLogger.Log($"Successfully called createOrderAsync with {bookingReference}, response booking ID {result};");
 
                 return result;
             }

--- a/HousingRepairsSchedulingApi/Services/Drs/DrsService.cs
+++ b/HousingRepairsSchedulingApi/Services/Drs/DrsService.cs
@@ -130,9 +130,12 @@ namespace HousingRepairsSchedulingApi.Services.Drs
             try
             {
                 var createOrderResponse = await _drsSoapClient.createOrderAsync(new createOrder(createOrder));
+
+                LambdaLogger.Log($"Successfully called createOrderAsync with {bookingReference}.");
+
                 var result = createOrderResponse.@return.theOrder.theBookings[0].bookingId;
 
-                LambdaLogger.Log($"Successfully called createOrderAsync with {bookingReference}, response booking ID {result};");
+                LambdaLogger.Log($"Returning result after sending work order {bookingReference} to DRS. Response booking ID: {result};");
 
                 return result;
             }


### PR DESCRIPTION
Added logging to display createOrderResponse after API call. This should show us the resulting object on which line 136 relies on
![image](https://user-images.githubusercontent.com/70756861/189112707-3b3aa3fc-093a-44a2-9cf0-9dad5918de10.png)

The error we're troubleshooting is the following:
`2022-09-08T11:04:27.158Z	11962800-abeb-4a19-8c1c-dda0d0f2585b	An error was thrown when calling bookAppointmentUseCase: "Serialization and deserialization of \u0027System.IntPtr\u0027 instances are not supported. Path: $.TargetSite.MethodHandle.Value."`

