### PR TITLE
Update log group name

### DIFF
--- a/terraform/production/cloudwatch_alarms.tf
+++ b/terraform/production/cloudwatch_alarms.tf
@@ -1,6 +1,6 @@
 locals {
   namespace = "HousingRepairsSchedulingApi-Businesslogic-Metrics"
-  log_group_name = "HousingRepairsSchedulingApi-production"
+  log_group_name = "/aws/lambda/HousingRepairsSchedulingApi-production"
 }
 
 resource "aws_sns_topic" "housing-repairs-scheduling-canary" {

--- a/terraform/staging/cloudwatch_alarms.tf
+++ b/terraform/staging/cloudwatch_alarms.tf
@@ -1,6 +1,6 @@
 locals {
   namespace = "HousingRepairsSchedulingApi-Businesslogic-Metrics"
-  log_group_name = "HousingRepairsSchedulingApi-staging"
+  log_group_name = "/aws/lambda/HousingRepairsSchedulingApi-staging"
 }
 
 resource "aws_sns_topic" "housing-repairs-scheduling-canary" {


### PR DESCRIPTION
Forgot to add `/aws/lambda/` to log group name. 

Screenshot of what worked in previous PR.

![image](https://user-images.githubusercontent.com/88662046/189881169-2b953636-465e-4e91-95f5-23c3a1f446fd.png)
