### PR TITLE
MR-510 - Added more logging in DrsService CreateOrder

### DIFF
--- a/HousingRepairsSchedulingApi/Services/Drs/DrsService.cs
+++ b/HousingRepairsSchedulingApi/Services/Drs/DrsService.cs
@@ -140,7 +140,26 @@ namespace HousingRepairsSchedulingApi.Services.Drs
             {
                 var createOrderResponse = await _drsSoapClient.createOrderAsync(new createOrder(createOrder));
 
-                LambdaLogger.Log($"Successfully called createOrderAsync with {bookingReference}. createOrderResponse: {JsonSerializer.Serialize(createOrderResponse)}");
+                LambdaLogger.Log($"Successfully called createOrderAsync with {bookingReference}. createOrderResponse: {createOrderResponse}");
+
+                if (createOrderResponse == null)
+                {
+                    LambdaLogger.Log($"'createOrderResponse' for booking reference {bookingReference} is null");
+                }
+                else
+                {
+                    LambdaLogger.Log($"'createOrderResponse' for booking reference {bookingReference} is not null");
+
+                }
+
+                if (createOrderResponse.@return == null)
+                {
+                    LambdaLogger.Log($"'createOrderResponse.@return' for booking reference {bookingReference} is null");
+                }
+                else
+                {
+                    LambdaLogger.Log($"'createOrderResponse.@return' for booking reference {bookingReference} is not null");
+                }
 
                 var result = createOrderResponse.@return.theOrder.theBookings[0].bookingId;
 


### PR DESCRIPTION
Before I was trying to Json serialize the response from CreateOrder, however this is an XML response. This may be why the output value in Cloudwatch looked like an empty object `{}` when calling `{JsonSerializer.Serialize(createOrderResponse)}`.

Not sure what result to expect by just logging `createOrderResponse`, however the additional checks I've put in place should give insight and inform us whether `createOrderResponse` is or isn't null, after the API call.