### PR TITLE
Add even more logging

### DIFF
--- a/HousingRepairsSchedulingApi/Services/Drs/DrsService.cs
+++ b/HousingRepairsSchedulingApi/Services/Drs/DrsService.cs
@@ -68,11 +68,11 @@ namespace HousingRepairsSchedulingApi.Services.Drs
             {
                 var checkAvailabilityResponse = await _drsSoapClient.checkAvailabilityAsync(new checkAvailability(checkAvailability));
 
-                _logger.LogInformation("Called checkAvailabilityAsync for {LocationId}, returning {Response}", locationId, checkAvailabilityResponse);
+                _logger.LogInformation("Called checkAvailabilityAsync for {LocationId}", locationId);
 
                 if (checkAvailabilityResponse?.@return?.theSlots == null)
                 {
-                    _logger.LogInformation("checkAvailabilityAsync for {LocationId} returns null", locationId);
+                    _logger.LogInformation("checkAvailabilityAsync returned an invalid response for {LocationId}", locationId);
                 }
 
                 var appointmentSlots = checkAvailabilityResponse.@return.theSlots
@@ -140,6 +140,11 @@ namespace HousingRepairsSchedulingApi.Services.Drs
             {
                 var createOrderResponse = await _drsSoapClient.createOrderAsync(new createOrder(createOrder));
 
+                if (createOrderResponse?.@return?.theOrder?.theBookings[0]?.bookingId == null)
+                {
+                    _logger.LogInformation("createOrderAsync returned an invalid response for {LocationId} ", locationId);
+                }
+
                 LambdaLogger.Log($"Successfully called createOrderAsync with {bookingReference}. createOrderResponse: {JsonSerializer.Serialize(createOrderResponse)}");
 
                 var result = createOrderResponse.@return.theOrder.theBookings[0].bookingId;
@@ -183,7 +188,6 @@ namespace HousingRepairsSchedulingApi.Services.Drs
             };
 
             _logger.LogInformation($"scheduleBooking object for booking reference {bookingReference}: {JsonSerializer.Serialize(scheduleBooking)}");
-
 
             try
             {

--- a/terraform/staging/cloudwatch_alarms.tf
+++ b/terraform/staging/cloudwatch_alarms.tf
@@ -7,26 +7,46 @@ resource "aws_sns_topic" "housing-repairs-scheduling-canary" {
   name = "housing-repairs-scheduling-canary"
 }
 
-// Matching Exceptions
-// "An error was thrown when calling _drsSoapClient.scheduleBookingAsync"
-// "An error was thrown when calling _drsSoapClient.createOrderAsync"
-// "An error was thrown when calling _drsSoapClient.checkAvailabilityAsync"
-
-resource "aws_cloudwatch_log_metric_filter" "housingrepairsschedulingapi-drs-exceptions-filter" {
-  name           = "HousingRepairsSchedulingAPI DRS Exceptions"
-  pattern        = "An error was thrown when calling _drsSoapClient"
+resource "aws_cloudwatch_log_metric_filter" "housingrepairsschedulingapi-drs-createorderasync-exceptions-filter" {
+  name           = "HousingRepairsSchedulingAPI DRS createOrderAsync Exceptions"
+  pattern        = "createOrderAsync returned an invalid response for"
   log_group_name = local.log_group_name
 
   metric_transformation {
-    name      = "HousingRepairsSchedulingAPI DRS Exceptions"
+    name      = "HousingRepairsSchedulingAPI DRS createOrderAsync Exceptions"
     namespace = local.namespace
     value     = "1"
   }
 }
 
-resource "aws_cloudwatch_metric_alarm" "housingrepairsschedulingapi-drs-exceptions-alarm" {
+resource "aws_cloudwatch_log_metric_filter" "housingrepairsschedulingapi-drs-checkavailabilityasync-exceptions-filter" {
+  name           = "HousingRepairsSchedulingAPI DRS checkAvailabilityAsync Exceptions"
+  pattern        = "checkAvailabilityAsync returned an invalid response for"
+  log_group_name = local.log_group_name
+
+  metric_transformation {
+    name      = "HousingRepairsSchedulingAPI DRS checkAvailabilityAsync Exceptions"
+    namespace = local.namespace
+    value     = "1"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "housingrepairsschedulingapi-drs-createorderasync-exceptions-alarm" {
   alarm_name          = "housingrepairsschedulingapi-drs-exceptions"
-  metric_name         = aws_cloudwatch_log_metric_filter.housingrepairsschedulingapi-drs-exceptions-filter.name
+  metric_name         = aws_cloudwatch_log_metric_filter.housingrepairsschedulingapi-drs-createorderasync-exceptions-filter.name
+  threshold           = "3"
+  statistic           = "Sum"
+  comparison_operator = "GreaterThanThreshold"
+  datapoints_to_alarm = "1"
+  evaluation_periods  = "1"
+  period              = "30"
+  namespace           = local.namespace
+  alarm_actions       = [aws_sns_topic.housing-repairs-scheduling-canary.arn]
+}
+
+resource "aws_cloudwatch_metric_alarm" "housingrepairsschedulingapi-drs-checkavailabilityasync-exceptions-alarm" {
+  alarm_name          = "housingrepairsschedulingapi-drs-exceptions"
+  metric_name         = aws_cloudwatch_log_metric_filter.housingrepairsschedulingapi-drs-checkavailabilityasync-exceptions-filter.name
   threshold           = "3"
   statistic           = "Sum"
   comparison_operator = "GreaterThanThreshold"


### PR DESCRIPTION
Add more logging to DRSService.

Without resulting to implementing XML deserialization, there isn't an easy way to determine if the soap response is invalid.

I have added logs into `CheckAvailability` and `CreateOrder` which will be called if the SOAP response didn't contain the expected data.

I also removed the try catch blocks in DrsService because they never get called.