### PR TITLE
Add terraform validate to pipeline + CloudWatch Alarm changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -220,13 +220,13 @@ workflows:
   check-and-deploy-staging-and-production:
     jobs:
       - check-code-formatting
-      # - build-and-test
+      - build-and-test
       # - terraform-validate-staging
       - assume-role-staging:
           context: api-assume-role-housing-staging-context
           requires:
             - check-code-formatting
-            # - build-and-test
+            - build-and-test
             # - terraform-validate-staging
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,6 +93,7 @@ commands:
           command: |
             cd ./terraform/<<parameters.environment>>/
             terraform get -update=true
+            terraform init
       - run:
           name: plan
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,12 +89,16 @@ commands:
       - *attach_workspace
       - checkout
       - run:
+          name: get and init
           command: |
             cd ./terraform/<<parameters.environment>>/
             terraform get -update=true
             terraform init
-            terraform validate -json
+      - run:
           name: validate
+          command: |
+            cd ./terraform/<<parameters.environment>>/
+            terraform validate -json
 
   terraform-init-then-apply:
     description: "Initializes and applies terraform configuration"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -220,14 +220,14 @@ workflows:
   check-and-deploy-staging-and-production:
     jobs:
       - check-code-formatting
-      - build-and-test
-      - terraform-validate-staging
+      # - build-and-test
+      # - terraform-validate-staging
       - assume-role-staging:
           context: api-assume-role-housing-staging-context
           requires:
             - check-code-formatting
-            - build-and-test
-            - terraform-validate-staging
+            # - build-and-test
+            # - terraform-validate-staging
           filters:
             branches:
               only: main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -221,15 +221,14 @@ workflows:
     jobs:
       - check-code-formatting
       - build-and-test
-      - assume-role-staging
-      - terraform-validate-staging:
-          requires:
-            - assume-role-staging
       - assume-role-staging:
           context: api-assume-role-housing-staging-context
           # filters:
           #   branches:
           #     only: main
+      - terraform-validate-staging:
+          requires:
+            - assume-role-staging
       - terraform-init-and-apply-to-staging:
           requires:
             - check-code-formatting

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,21 +80,21 @@ commands:
             cd ./HousingRepairsSchedulingApi/
             sls deploy --stage <<parameters.stage>> --conceal
 
-    terraform-validate:
-      description: "Validate terraform configuration"
-      parameters:
-        environment:
-          type: string
-      steps:
-        - *attach_workspace
-        - checkout
-        - run:
-            command: |
-              cd ./terraform/<<parameters.environment>>/
-              terraform get -update=true
-              terraform init
-              terraform validate -json
-            name: validate
+  terraform-validate:
+    description: "Validate terraform configuration"
+    parameters:
+      environment:
+        type: string
+    steps:
+      - *attach_workspace
+      - checkout
+      - run:
+          command: |
+            cd ./terraform/<<parameters.environment>>/
+            terraform get -update=true
+            terraform init
+            terraform validate -json
+          name: validate
 
   terraform-init-then-apply:
     description: "Initializes and applies terraform configuration"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,12 +93,11 @@ commands:
           command: |
             cd ./terraform/<<parameters.environment>>/
             terraform get -update=true
-            terraform init
       - run:
-          name: validate
+          name: plan
           command: |
             cd ./terraform/<<parameters.environment>>/
-            terraform validate -json
+            terraform plan
 
   terraform-init-then-apply:
     description: "Initializes and applies terraform configuration"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -173,7 +173,7 @@ jobs:
       - assume-role-and-persist-workspace:
           aws-account: $AWS_ACCOUNT_PRODUCTION
   terraform-validate-staging:
-    executor: terraform-validate
+    executor: docker-terraform
     steps:
       - terraform-validate:
           environment: "staging"
@@ -221,13 +221,13 @@ workflows:
     jobs:
       - check-code-formatting
       - build-and-test
-      # - terraform-validate-staging
+      - terraform-validate-staging
       - assume-role-staging:
           context: api-assume-role-housing-staging-context
           requires:
             - check-code-formatting
             - build-and-test
-            # - terraform-validate-staging
+            - terraform-validate-staging
           filters:
             branches:
               only: main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,6 +80,22 @@ commands:
             cd ./HousingRepairsSchedulingApi/
             sls deploy --stage <<parameters.stage>> --conceal
 
+    terraform-validate:
+      description: "Validate terraform configuration"
+      parameters:
+        environment:
+          type: string
+      steps:
+        - *attach_workspace
+        - checkout
+        - run:
+            command: |
+              cd ./terraform/<<parameters.environment>>/
+              terraform get -update=true
+              terraform init
+              terraform validate -json
+            name: validate
+
   terraform-init-then-apply:
     description: "Initializes and applies terraform configuration"
     parameters:
@@ -178,6 +194,7 @@ workflows:
           context: api-nuget-token-context
       - build-and-test:
           context: api-nuget-token-context
+      - terraform-validate
       - assume-role-development:
           context: api-assume-role-housing-development-context
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -188,41 +188,41 @@ jobs:
       - terraform-init-then-apply:
           environment: "production"
 workflows:
-  check-and-deploy-development:
-    jobs:
-      - check-code-formatting:
-          context: api-nuget-token-context
-      - build-and-test:
-          context: api-nuget-token-context
-      - terraform-validate
-      - assume-role-development:
-          context: api-assume-role-housing-development-context
-          requires:
-            - build-and-test
-          filters:
-            branches:
-              only: development
-      - terraform-init-and-apply-to-development:
-          requires:
-            - assume-role-development
-          filters:
-            branches:
-              only: development
-      - deploy-to-development:
-          requires:
-            - assume-role-development
-            - terraform-init-and-apply-to-development
+  # check-and-deploy-development:
+  #   jobs:
+  #     - check-code-formatting:
+  #         context: api-nuget-token-context
+  #     - build-and-test:
+  #         context: api-nuget-token-context
+  #     - terraform-validate
+  #     - assume-role-development:
+  #         context: api-assume-role-housing-development-context
+  #         requires:
+  #           - build-and-test
+  #         filters:
+  #           branches:
+  #             only: development
+  #     - terraform-init-and-apply-to-development:
+  #         requires:
+  #           - assume-role-development
+  #         filters:
+  #           branches:
+  #             only: development
+  #     - deploy-to-development:
+  #         requires:
+  #           - assume-role-development
+  #           - terraform-init-and-apply-to-development
   check-and-deploy-staging-and-production:
     jobs:
-      - build-and-test:
-          context: api-nuget-token-context
-          filters:
-            branches:
-              only: main
+      - check-code-formatting
+      - build-and-test
+      - terraform-validate
       - assume-role-staging:
           context: api-assume-role-housing-staging-context
           requires:
+            - check-code-formatting
             - build-and-test
+            - terraform-validate
           filters:
             branches:
               only: main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,8 +80,8 @@ commands:
             cd ./HousingRepairsSchedulingApi/
             sls deploy --stage <<parameters.stage>> --conceal
 
-  terraform-validate:
-    description: "Validate terraform configuration"
+  terraform-plan:
+    description: "Plan and validate terraform configuration"
     parameters:
       environment:
         type: string
@@ -176,10 +176,10 @@ jobs:
     steps:
       - assume-role-and-persist-workspace:
           aws-account: $AWS_ACCOUNT_PRODUCTION
-  terraform-validate-staging:
+  terraform-plan-staging:
     executor: docker-terraform
     steps:
-      - terraform-validate:
+      - terraform-plan:
           environment: "staging"
   terraform-init-and-apply-to-development:
     executor: docker-terraform
@@ -230,14 +230,14 @@ workflows:
           # filters:
           #   branches:
           #     only: main
-      - terraform-validate-staging:
+      - terraform-plan-staging:
           requires:
             - assume-role-staging
       - terraform-init-and-apply-to-staging:
           requires:
             - check-code-formatting
             - build-and-test
-            - terraform-validate-staging
+            - terraform-plan-staging
           filters:
             branches:
               only: main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -172,6 +172,11 @@ jobs:
     steps:
       - assume-role-and-persist-workspace:
           aws-account: $AWS_ACCOUNT_PRODUCTION
+  terraform-validate-staging:
+    executor: terraform-validate
+    steps:
+      - terraform-validate:
+          environment: "staging"
   terraform-init-and-apply-to-development:
     executor: docker-terraform
     steps:
@@ -216,13 +221,13 @@ workflows:
     jobs:
       - check-code-formatting
       - build-and-test
-      - terraform-validate
+      - terraform-validate-staging
       - assume-role-staging:
           context: api-assume-role-housing-staging-context
           requires:
             - check-code-formatting
             - build-and-test
-            - terraform-validate
+            - terraform-validate-staging
           filters:
             branches:
               only: main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -223,7 +223,7 @@ workflows:
       - build-and-test
       - assume-role-staging
       - terraform-validate-staging:
-        requires:
+          requires:
             - assume-role-staging
       - assume-role-staging:
           context: api-assume-role-housing-staging-context

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -221,19 +221,20 @@ workflows:
     jobs:
       - check-code-formatting
       - build-and-test
-      - terraform-validate-staging
+      - assume-role-staging
+      - terraform-validate-staging:
+        requires:
+            - assume-role-staging
       - assume-role-staging:
           context: api-assume-role-housing-staging-context
+          # filters:
+          #   branches:
+          #     only: main
+      - terraform-init-and-apply-to-staging:
           requires:
             - check-code-formatting
             - build-and-test
             - terraform-validate-staging
-          filters:
-            branches:
-              only: main
-      - terraform-init-and-apply-to-staging:
-          requires:
-            - assume-role-staging
           filters:
             branches:
               only: main

--- a/terraform/production/cloudwatch_alarms.tf
+++ b/terraform/production/cloudwatch_alarms.tf
@@ -7,26 +7,46 @@ resource "aws_sns_topic" "housing-repairs-scheduling-canary" {
   name = "housing-repairs-scheduling-canary"
 }
 
-// Matching Exceptions
-// "An error was thrown when calling _drsSoapClient.scheduleBookingAsync"
-// "An error was thrown when calling _drsSoapClient.createOrderAsync"
-// "An error was thrown when calling _drsSoapClient.checkAvailabilityAsync"
-
-resource "aws_cloudwatch_log_metric_filter" "housingrepairsschedulingapi-drs-exceptions-filter" {
-  name           = "HousingRepairsSchedulingAPI DRS Exceptions"
-  pattern        = "An error was thrown when calling _drsSoapClient"
+resource "aws_cloudwatch_log_metric_filter" "housingrepairsschedulingapi-drs-createorderasync-exceptions-filter" {
+  name           = "HousingRepairsSchedulingAPI DRS createOrderAsync Exceptions"
+  pattern        = "createOrderAsync returned an invalid response for"
   log_group_name = local.log_group_name
 
   metric_transformation {
-    name      = "HousingRepairsSchedulingAPI DRS Exceptions"
+    name      = "HousingRepairsSchedulingAPI DRS createOrderAsync Exceptions"
     namespace = local.namespace
     value     = "1"
   }
 }
 
-resource "aws_cloudwatch_metric_alarm" "housingrepairsschedulingapi-drs-exceptions-alarm" {
-  alarm_name          = "housingrepairsschedulingapi-drs-exceptions"
-  metric_name         = aws_cloudwatch_log_metric_filter.housingrepairsschedulingapi-drs-exceptions-filter.name
+resource "aws_cloudwatch_log_metric_filter" "housingrepairsschedulingapi-drs-checkavailabilityasync-exceptions-filter" {
+  name           = "HousingRepairsSchedulingAPI DRS checkAvailabilityAsync Exceptions"
+  pattern        = "checkAvailabilityAsync returned an invalid response for"
+  log_group_name = local.log_group_name
+
+  metric_transformation {
+    name      = "HousingRepairsSchedulingAPI DRS checkAvailabilityAsync Exceptions"
+    namespace = local.namespace
+    value     = "1"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "housingrepairsschedulingapi-drs-createorderasync-exceptions-alarm" {
+  alarm_name          = "housingrepairsschedulingapi-drs-createorderasync-exceptions"
+  metric_name         = aws_cloudwatch_log_metric_filter.housingrepairsschedulingapi-drs-createorderasync-exceptions-filter.name
+  threshold           = "3"
+  statistic           = "Sum"
+  comparison_operator = "GreaterThanThreshold"
+  datapoints_to_alarm = "1"
+  evaluation_periods  = "1"
+  period              = "30"
+  namespace           = local.namespace
+  alarm_actions       = [aws_sns_topic.housing-repairs-scheduling-canary.arn]
+}
+
+resource "aws_cloudwatch_metric_alarm" "housingrepairsschedulingapi-drs-checkavailabilityasync-exceptions-alarm" {
+  alarm_name          = "housingrepairsschedulingapi-drs-checkavailabilityasync-exceptions"
+  metric_name         = aws_cloudwatch_log_metric_filter.housingrepairsschedulingapi-drs-checkavailabilityasync-exceptions-filter.name
   threshold           = "3"
   statistic           = "Sum"
   comparison_operator = "GreaterThanThreshold"

--- a/terraform/staging/cloudwatch_alarms.tf
+++ b/terraform/staging/cloudwatch_alarms.tf
@@ -32,7 +32,7 @@ resource "aws_cloudwatch_log_metric_filter" "housingrepairsschedulingapi-drs-che
 }
 
 resource "aws_cloudwatch_metric_alarm" "housingrepairsschedulingapi-drs-createorderasync-exceptions-alarm" {
-  alarm_name          = "housingrepairsschedulingapi-drs-exceptions"
+  alarm_name          = "housingrepairsschedulingapi-drs-createorderasync-exceptions"
   metric_name         = aws_cloudwatch_log_metric_filter.housingrepairsschedulingapi-drs-createorderasync-exceptions-filter.name
   threshold           = "3"
   statistic           = "Sum"
@@ -45,7 +45,7 @@ resource "aws_cloudwatch_metric_alarm" "housingrepairsschedulingapi-drs-createor
 }
 
 resource "aws_cloudwatch_metric_alarm" "housingrepairsschedulingapi-drs-checkavailabilityasync-exceptions-alarm" {
-  alarm_name          = "housingrepairsschedulingapi-drs-exceptions"
+  alarm_name          = "housingrepairsschedulingapi-drs-checkavailabilityasync-exceptions"
   metric_name         = aws_cloudwatch_log_metric_filter.housingrepairsschedulingapi-drs-checkavailabilityasync-exceptions-filter.name
   threshold           = "3"
   statistic           = "Sum"

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -3,7 +3,7 @@ provider "aws" {
 }
 data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
-locals {
+locs {
   application_name = "housing-repairs-scheduling-api" # The name to use for your application
 }
 

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -3,7 +3,7 @@ provider "aws" {
 }
 data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
-locs {
+locals {
   application_name = "housing-repairs-scheduling-api" # The name to use for your application
 }
 


### PR DESCRIPTION
## Summary of changes

There are two parts to this PR, fixing the terraform for CloudWatch Alarms, then updating circleci pipeline and adding terraform plan.

### Updating Cloudwatch Alarms Terraform

1. I forgot to give each alarm a unique name
2. I also forgot to apply the same changes to production

### Updating the Pipeline

1. The pipeline was configured to run on dev, which we arent currently using. So I have changed the config to run on main.
2. I find it annoying that I cannot verify if Terraform config is invalid until the PR has been merged. By running `terraform plan`, I will know before I merge. 