### PR TITLE
MR-510 - Commented out logging

### DIFF
--- a/HousingRepairsSchedulingApi/Services/Drs/DrsService.cs
+++ b/HousingRepairsSchedulingApi/Services/Drs/DrsService.cs
@@ -140,15 +140,15 @@ namespace HousingRepairsSchedulingApi.Services.Drs
 
             LambdaLogger.Log($"'createOrderResponse.@return' for booking reference {bookingReference}" + ((createOrderResponse?.@return == null) ? "is null" : "is not null"));
 
-            LambdaLogger.Log($"'createOrderResponse.@return.theOrder.theBookings[0].bookingId' for booking reference {bookingReference}: {createOrderResponse?.@return?.theOrder?.theBookings[0]?.bookingId}");
+            //LambdaLogger.Log($"'createOrderResponse.@return.theOrder.theBookings[0].bookingId' for booking reference {bookingReference}: {createOrderResponse?.@return?.theOrder?.theBookings[0]?.bookingId}");
 
-            LambdaLogger.Log($"Output from'createOrderResponse.@return.theOrder.theBookings' arrayfor booking reference {bookingReference}. Result: {createOrderResponse?.@return?.theOrder?.theBookings}");
+            //LambdaLogger.Log($"Output from'createOrderResponse.@return.theOrder.theBookings' arrayfor booking reference {bookingReference}. Result: {createOrderResponse?.@return?.theOrder?.theBookings}");
 
-            LambdaLogger.Log($"Attempting to JSON Serialize 'createOrderResponse.@return.theOrder.theBookings[0]' for booking reference {bookingReference}. Result: {JsonSerializer.Serialize(createOrderResponse?.@return?.theOrder?.theBookings[0])}");
+            //LambdaLogger.Log($"Attempting to JSON Serialize 'createOrderResponse.@return.theOrder.theBookings[0]' for booking reference {bookingReference}. Result: {JsonSerializer.Serialize(createOrderResponse?.@return?.theOrder?.theBookings[0])}");
 
-            LambdaLogger.Log($"Primary Order Number from 'createOrderResponse.@return.theOrder.primaryOrderNumber' for booking reference {bookingReference}. Result: {createOrderResponse?.@return?.theOrder?.primaryOrderNumber}");
+            //LambdaLogger.Log($"Primary Order Number from 'createOrderResponse.@return.theOrder.primaryOrderNumber' for booking reference {bookingReference}. Result: {createOrderResponse?.@return?.theOrder?.primaryOrderNumber}");
 
-            LambdaLogger.Log($"Contract from 'createOrderResponse.@return.theOrder.theBookings[0].contract' for booking reference {bookingReference}. Result: {createOrderResponse?.@return?.theOrder?.theBookings[0]?.contract}");
+            //LambdaLogger.Log($"Contract from 'createOrderResponse.@return.theOrder.theBookings[0].contract' for booking reference {bookingReference}. Result: {createOrderResponse?.@return?.theOrder?.theBookings[0]?.contract}");
 
             var result = createOrderResponse.@return.theOrder.theBookings[0].bookingId;
 


### PR DESCRIPTION
Cannot see the Serialization/deserialization error anymore after adding a lot of logging lines.

![image](https://user-images.githubusercontent.com/70756861/190362691-2710928d-62ae-43b3-9358-7d41fcc85a47.png)

![image](https://user-images.githubusercontent.com/70756861/190362713-cb6b1ba9-378d-42bf-966f-49d95bf0249a.png)

Potentially the logging is triggering now another error:

`An error was thrown when calling bookAppointmentUseCase: "Object reference not set to an instance of an object."`

but not sure which line of logging is causing this. This PR should take the code back to a state where we can see the original error again. I may need to add logging one by one.