### PR TITLE
MR-510 - DRS time slot fix for orders coming from Online Repairs

### DIFF
--- a/HousingRepairsSchedulingApi.Tests/GatewaysTests/DrsAppointmentGatewayTests.cs
+++ b/HousingRepairsSchedulingApi.Tests/GatewaysTests/DrsAppointmentGatewayTests.cs
@@ -17,6 +17,7 @@ namespace HousingRepairsSchedulingApi.Tests.GatewaysTests
     {
         private Mock<IDrsService> drsServiceMock = new();
         private DrsAppointmentGateway systemUnderTest;
+        private const int WorkOrderId = 10000047;
         private const int RequiredNumberOfAppointmentDays = 5;
         private const int AppointmentSearchTimeSpanInDays = 14;
         private const int AppointmentLeadTimeInDays = 0;
@@ -618,23 +619,23 @@ namespace HousingRepairsSchedulingApi.Tests.GatewaysTests
 
         [Fact]
 #pragma warning disable CA1707
-        public async void GivenValidArguments_WhenExecute_ThenBookingReferenceIsReturned()
+        public async void GivenValidArguments_WhenExecute_ThenOrderIsReturned()
 #pragma warning restore CA1707
         {
             // Arrange
-            const int bookingId = 12345;
+            var bookingReference = "10003829";
 
             drsServiceMock.Setup(x =>
-                x.CreateOrder(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>())
-            ).ReturnsAsync(bookingId);
+                x.SelectOrder(It.IsAny<int>(), It.IsAny<DateTime?>())
+            ).ReturnsAsync(new order { orderId = 863256, theBookings = new booking[] { new booking { bookingId = 12345 } } });
 
             // Act
             var startDateTime = new DateTime(2022, 05, 01);
-            var actual = await systemUnderTest.BookAppointment(BookingReference, SorCode, LocationId,
+            var actual = await systemUnderTest.BookAppointment(bookingReference, SorCode, LocationId,
                 startDateTime, startDateTime.AddDays(1));
 
             // Assert
-            Assert.Equal(BookingReference, actual);
+            Assert.Equal(bookingReference, actual);
         }
     }
 }

--- a/HousingRepairsSchedulingApi.Tests/GatewaysTests/DrsAppointmentGatewayTests.cs
+++ b/HousingRepairsSchedulingApi.Tests/GatewaysTests/DrsAppointmentGatewayTests.cs
@@ -641,21 +641,20 @@ namespace HousingRepairsSchedulingApi.Tests.GatewaysTests
 
         public static IEnumerable<object[]> InvalidOrderTestData()
         {
-            yield return new object[] { new DrsException(), "10003829", new DateTime(2022, 05, 01), (order)null };
-            yield return new object[] { new DrsException(), "10003829", new DateTime(2022, 05, 01), new order { orderComments = "No bookings in this order" } };
-            yield return new object[] { new DrsException(), "10003829", new DateTime(2022, 05, 01), new order { theBookings = new booking[] { new booking { bookingId = 0 } } } };
+            yield return new object[] {"10003829", new DateTime(2022, 05, 01), (order)null };
+            yield return new object[] {"10003829", new DateTime(2022, 05, 01), new order { orderComments = "No bookings in this order" } };
+            yield return new object[] {"10003829", new DateTime(2022, 05, 01), new order { theBookings = new booking[] { new booking { bookingId = 0 } } } };
         }
 
         [Theory]
         [MemberData(nameof(InvalidOrderTestData))]
 #pragma warning disable xUnit1026
 #pragma warning disable CA1707
-        public async void GivenInvalidOrderIsReturned_WhenSelectingAnOrder_ThenExceptionIsThrown<T>(
-            T exception,
+        public async void GivenInvalidOrderIsReturned_WhenSelectingAnOrder_ThenExceptionIsThrown(
             string bookingReference,
             DateTime startDateTime,
             order orderResponse
-            ) where T : Exception
+            )
 #pragma warning restore CA1707
 #pragma warning restore xUnit1026
         {
@@ -669,7 +668,7 @@ namespace HousingRepairsSchedulingApi.Tests.GatewaysTests
                 startDateTime, startDateTime.AddDays(1));
 
             // Assert
-            await act.Should().ThrowExactlyAsync<T>();
+            await act.Should().ThrowAsync<DrsException>();
         }
     }
 }

--- a/HousingRepairsSchedulingApi.Tests/GatewaysTests/DrsAppointmentGatewayTests.cs
+++ b/HousingRepairsSchedulingApi.Tests/GatewaysTests/DrsAppointmentGatewayTests.cs
@@ -9,6 +9,7 @@ namespace HousingRepairsSchedulingApi.Tests.GatewaysTests
     using FluentAssertions;
     using Gateways;
     using HousingRepairsSchedulingApi.Exceptions;
+    using HousingRepairsSchedulingApi.Helpers;
     using Microsoft.Extensions.Logging.Abstractions;
     using Moq;
     using Services.Drs;
@@ -620,12 +621,15 @@ namespace HousingRepairsSchedulingApi.Tests.GatewaysTests
 
         [Fact]
 #pragma warning disable CA1707
-        public async void GivenValidArguments_WhenExecute_ThenOrderIsReturned()
+        public async void GivenValidArguments_WhenExecute_ThenOrderIsReturnedAndScheduleBookingIsCalled()
 #pragma warning restore CA1707
         {
             // Arrange
             var bookingReference = "10003829";
             var startDateTime = new DateTime(2022, 05, 01);
+            var endDateTime = startDateTime.AddDays(1);
+            var convertedStartTime = DrsHelpers.ConvertToDrsTimeZone(startDateTime);
+            var convertedEndTime = DrsHelpers.ConvertToDrsTimeZone(startDateTime.AddDays(1));
 
             drsServiceMock.Setup(x =>
                 x.SelectOrder(It.IsAny<int>(), It.IsAny<DateTime?>())
@@ -637,6 +641,7 @@ namespace HousingRepairsSchedulingApi.Tests.GatewaysTests
 
             // Assert
             Assert.Equal(bookingReference, actual);
+            drsServiceMock.Verify(drsServiceMock => drsServiceMock.ScheduleBooking(bookingReference, 12345, convertedStartTime, convertedEndTime), Times.Once);
         }
 
         public static IEnumerable<object[]> InvalidOrderTestData()

--- a/HousingRepairsSchedulingApi.Tests/GatewaysTests/DrsAppointmentGatewayTests.cs
+++ b/HousingRepairsSchedulingApi.Tests/GatewaysTests/DrsAppointmentGatewayTests.cs
@@ -646,9 +646,9 @@ namespace HousingRepairsSchedulingApi.Tests.GatewaysTests
 
         public static IEnumerable<object[]> InvalidOrderTestData()
         {
-            yield return new object[] {"10003829", new DateTime(2022, 05, 01), (order)null };
-            yield return new object[] {"10003829", new DateTime(2022, 05, 01), new order { orderComments = "No bookings in this order" } };
-            yield return new object[] {"10003829", new DateTime(2022, 05, 01), new order { theBookings = new booking[] { new booking { bookingId = 0 } } } };
+            yield return new object[] { "10003829", new DateTime(2022, 05, 01), (order)null };
+            yield return new object[] { "10003829", new DateTime(2022, 05, 01), new order { orderComments = "No bookings in this order" } };
+            yield return new object[] { "10003829", new DateTime(2022, 05, 01), new order { theBookings = new booking[] { new booking { bookingId = 0 } } } };
         }
 
         [Theory]

--- a/HousingRepairsSchedulingApi.Tests/GatewaysTests/DrsAppointmentGatewayTests.cs
+++ b/HousingRepairsSchedulingApi.Tests/GatewaysTests/DrsAppointmentGatewayTests.cs
@@ -641,74 +641,25 @@ namespace HousingRepairsSchedulingApi.Tests.GatewaysTests
 
         public static IEnumerable<object[]> InvalidOrderTestData()
         {
-            yield return new object[] { new DrsException() };
+            yield return new object[] { new DrsException(), "10003829", new DateTime(2022, 05, 01), (order)null };
+            yield return new object[] { new DrsException(), "10003829", new DateTime(2022, 05, 01), new order { orderComments = "No bookings in this order" } };
+            yield return new object[] { new DrsException(), "10003829", new DateTime(2022, 05, 01), new order { theBookings = new booking[] { new booking { bookingId = 0 } } } };
         }
 
         [Theory]
         [MemberData(nameof(InvalidOrderTestData))]
 #pragma warning disable xUnit1026
 #pragma warning disable CA1707
-        public async void GivenANullOrderIsReturned_WhenSelectingAnOrder_ThenExceptionIsThrown<T>(T exception) where T : Exception
+        public async void GivenInvalidOrderIsReturned_WhenSelectingAnOrder_ThenExceptionIsThrown<T>(
+            T exception,
+            string bookingReference,
+            DateTime startDateTime,
+            order orderResponse
+            ) where T : Exception
 #pragma warning restore CA1707
 #pragma warning restore xUnit1026
         {
             // Arrange
-            var bookingReference = "10003829";
-            var startDateTime = new DateTime(2022, 05, 01);
-
-            drsServiceMock.Setup(x =>
-                x.SelectOrder(It.IsAny<int>(), It.IsAny<DateTime?>())
-            ).ReturnsAsync((order)null);
-
-            // Act
-            var act = async () => await systemUnderTest.BookAppointment(bookingReference, SorCode, LocationId,
-                startDateTime, startDateTime.AddDays(1));
-
-            // Assert
-            await act.Should().ThrowExactlyAsync<T>();
-        }
-
-        [Theory]
-        [MemberData(nameof(InvalidOrderTestData))]
-#pragma warning disable xUnit1026
-#pragma warning disable CA1707
-        public async void GivenNoBookingsPresentInTheOrderResponse_WhenSelectingAnOrder_ThenExceptionIsThrown<T>(T exception) where T : Exception
-#pragma warning restore CA1707
-#pragma warning restore xUnit1026
-        {
-            // Arrange
-            var bookingReference = "10003829";
-            var startDateTime = new DateTime(2022, 05, 01);
-
-            drsServiceMock.Setup(x =>
-                x.SelectOrder(It.IsAny<int>(), It.IsAny<DateTime?>())
-            ).ReturnsAsync(new order { orderComments = "No bookings in this order" });
-
-            // Act
-            var act = async () => await systemUnderTest.BookAppointment(bookingReference, SorCode, LocationId,
-                startDateTime, startDateTime.AddDays(1));
-
-            // Assert
-            await act.Should().ThrowExactlyAsync<T>();
-        }
-
-        public static IEnumerable<object[]> InvalidBookingIdTestData()
-        {
-            yield return new object[] { new DrsException(), new order { theBookings = new booking[] { new booking { bookingId = 0 } } } };
-        }
-
-        [Theory]
-        [MemberData(nameof(InvalidBookingIdTestData))]
-#pragma warning disable xUnit1026
-#pragma warning disable CA1707
-        public async void GivenInvalidBookingIdTheOrderResponse_WhenSelectingAnOrder_ThenExceptionIsThrown<T>(T exception, order orderResponse) where T : Exception
-#pragma warning restore CA1707
-#pragma warning restore xUnit1026
-        {
-            // Arrange
-            var bookingReference = "10003829";
-            var startDateTime = new DateTime(2022, 05, 01);
-
             drsServiceMock.Setup(x =>
                 x.SelectOrder(It.IsAny<int>(), It.IsAny<DateTime?>())
             ).ReturnsAsync(orderResponse);

--- a/HousingRepairsSchedulingApi.Tests/ServicesTests/Drs/DrsServiceTests.cs
+++ b/HousingRepairsSchedulingApi.Tests/ServicesTests/Drs/DrsServiceTests.cs
@@ -244,7 +244,7 @@ namespace HousingRepairsSchedulingApi.Tests.ServicesTests.Drs
                 .ReturnsAsync(new createOrderResponse(new xmbCreateOrderResponse
                 {
                     status = responseStatus.success,
-                    theOrder = new order {theBookings = new[] { new booking { bookingId = BookingId } } }
+                    theOrder = new order { theBookings = new[] { new booking { bookingId = BookingId } } }
                 }));
 
             // Act
@@ -252,7 +252,6 @@ namespace HousingRepairsSchedulingApi.Tests.ServicesTests.Drs
 
             // Assert
             Assert.Equal(BookingId, actual);
-
         }
 
 

--- a/HousingRepairsSchedulingApi.Tests/ServicesTests/Drs/DrsServiceTests.cs
+++ b/HousingRepairsSchedulingApi.Tests/ServicesTests/Drs/DrsServiceTests.cs
@@ -243,7 +243,8 @@ namespace HousingRepairsSchedulingApi.Tests.ServicesTests.Drs
             this.soapMock.Setup(x => x.createOrderAsync(It.IsAny<createOrder>()))
                 .ReturnsAsync(new createOrderResponse(new xmbCreateOrderResponse
                 {
-                    theOrder = new order { theBookings = new[] { new booking { bookingId = BookingId } } }
+                    status = responseStatus.success,
+                    theOrder = new order {theBookings = new[] { new booking { bookingId = BookingId } } }
                 }));
 
             // Act

--- a/HousingRepairsSchedulingApi/Exceptions/DrsException.cs
+++ b/HousingRepairsSchedulingApi/Exceptions/DrsException.cs
@@ -1,0 +1,11 @@
+namespace HousingRepairsSchedulingApi.Exceptions
+{
+    using System;
+
+    public class DrsException : Exception
+    {
+        public DrsException() { }
+        public DrsException(string errorMessage) => this.ErrorMessage = errorMessage;
+        public string ErrorMessage { get; set; }
+    }
+}

--- a/HousingRepairsSchedulingApi/Gateways/DrsAppointmentGateway.cs
+++ b/HousingRepairsSchedulingApi/Gateways/DrsAppointmentGateway.cs
@@ -129,7 +129,7 @@ namespace HousingRepairsSchedulingApi.Gateways
                 throw new DrsException($"No valid booking found in DRS order with booking reference {bookingReference}");
             }
 
-            if (order.theBookings[0].bookingId == null || order.theBookings[0].bookingId == 0)
+            if (order.theBookings[0].bookingId == 0)
             {
                 throw new DrsException($"Booking ID for DRS order with booking reference {bookingReference} is invalid");
             }

--- a/HousingRepairsSchedulingApi/Services/Drs/DrsService.cs
+++ b/HousingRepairsSchedulingApi/Services/Drs/DrsService.cs
@@ -259,7 +259,7 @@ namespace HousingRepairsSchedulingApi.Services.Drs
                     }
                     else
                     {
-                        throw new Exception($"Error with work order ID: {workOrderId}. {selectOrderResponse.@return.errorMsg}");
+                        throw new Exception($"An error occurred while attempting to select work order ID {workOrderId}. {selectOrderResponse.@return.errorMsg}");
                     }
                 }
                 return null;

--- a/HousingRepairsSchedulingApi/Services/Drs/DrsService.cs
+++ b/HousingRepairsSchedulingApi/Services/Drs/DrsService.cs
@@ -135,7 +135,7 @@ namespace HousingRepairsSchedulingApi.Services.Drs
             {
                 var errorMessage = createOrderResponse.@return.errorMsg;
 
-                LambdaLogger.Log($"An error occurred while attempting to create and order booking reference {bookingReference}: {errorMessage}");
+                _logger.LogError($"An error occurred while attempting to create an order with booking reference {bookingReference}: {errorMessage}");
                 throw new DrsException(errorMessage);
             }
 

--- a/HousingRepairsSchedulingApi/Services/Drs/DrsService.cs
+++ b/HousingRepairsSchedulingApi/Services/Drs/DrsService.cs
@@ -134,8 +134,6 @@ namespace HousingRepairsSchedulingApi.Services.Drs
             if (createOrderResponse.@return.status != responseStatus.success)
             {
                 var errorMessage = createOrderResponse.@return.errorMsg;
-
-                _logger.LogError($"An error occurred while attempting to create an order with booking reference {bookingReference}: {errorMessage}");
                 throw new DrsException(errorMessage);
             }
 

--- a/HousingRepairsSchedulingApi/Services/Drs/IDrsService.cs
+++ b/HousingRepairsSchedulingApi/Services/Drs/IDrsService.cs
@@ -12,5 +12,7 @@ namespace HousingRepairsSchedulingApi.Services.Drs
         Task<int> CreateOrder(string bookingReference, string sorCode, string locationId);
 
         Task ScheduleBooking(string bookingReference, int bookingId, DateTime startDateTime, DateTime endDateTime);
+
+        Task<order> SelectOrder(int workOrderId, DateTime? validationDate);
     }
 }


### PR DESCRIPTION
This PR aims to resolve the issue with the Time Window being sent into DRS
![image](https://user-images.githubusercontent.com/70756861/191007210-04ba5946-7e66-4925-8688-3582d93244cd.png)

The issue was the the Work Order reference was being created twice, initially by the Repairs API, and secondly by the HousingRepairsSchedulingAPI. As the order was created twice, when attempting to create the order a second time, the response from the API would error, and return a booking ID of 0, which would cause an error in the code and which also meant _drsService.ScheduleBooking (within BookAppointment of the SchedulingAPI), would never be called and would never send the timeslot chosen by the user, to DRS.

Commits:
- Created DrsException class
- Added SelectOrder method to IDRSService interface
- Added SelectOrder method to DrsService
- Replaced CreateOrder with SelectOrder in BookAppointment as the order already exists at this point. Added validation once the order is retrieved.
- Replaced CreateOrder test in DrsAppointmentGateway with a new SelectOrder test to reflect the change.
- Changed log type (from info to error)
- Removed null check on integer as it should never be null being of int type.
- Added BookAppointment tests for invalid responses after SelectOrder is triggered. All three exceptions added are tested.
- Removed repeated code and created one object to contain test data for each exception scenario
- [Added response status to DrsService.CreateOrder test after adding a check on the code to make sure response is "success".
- Fixed formatting.

**Note: all the logging previously put in place will be removed in a separate PR, once we've confirmed that the issue has been resolved.**